### PR TITLE
Update Bumblekin and add Reality Engine origin

### DIFF
--- a/kubejs/data/ht32/origins/bumblekin.json
+++ b/kubejs/data/ht32/origins/bumblekin.json
@@ -5,7 +5,10 @@
         "ht32:hively_home",
         "ht32:wax_weaver",
         "ht32:hive_protection",
-        "origins:fragile"
+        "ht32:barbed_stinger",
+        "origins:fragile",
+        "ht32:bbread_buff",
+        "origins:arthropod"
     ],
     "icon": {
         "item": "the_bumblezone:stingless_bee_helmet_1"

--- a/kubejs/data/ht32/powers/barbed_stinger.json
+++ b/kubejs/data/ht32/powers/barbed_stinger.json
@@ -1,0 +1,33 @@
+{
+    "type": "origins:action_on_hit",
+    "bientity_action": {
+        "type": "origins:and",
+        "actions": [
+            {
+                "type": "origins:actor_action",
+                "action": {
+                    "type": "origins:damage",
+                    "amount": 3,
+                    "damage_type": "minecraft:generic"
+                }
+            },
+            {
+                "type": "origins:target_action",
+                "action": {
+                    "type": "origins:apply_effect",
+                    "effect": {
+                        "effect": "minecraft:poison",
+                        "duration": 240,
+                        "amplifier": 0
+                    }
+                }
+            }
+        ]
+    },
+    "damage_condition": {
+        "type": "origins:projectile",
+        "inverted": true
+    },
+    "name": "Barbed Stinger",
+    "description": "You apply poison when directly attacking but also take one and a half hearts of damage."
+}

--- a/kubejs/data/ht32/powers/bbread_buff.json
+++ b/kubejs/data/ht32/powers/bbread_buff.json
@@ -1,0 +1,15 @@
+{
+    "type": "origins:action_on_item_use",
+    "entity_action": {
+        "type": "origins:feed",
+        "food": 1,
+        "saturation": 3
+    },
+    "item_condition": {
+        "type": "origins:ingredient",
+        "ingredient": {
+            "item": "the_bumblezone:bee_bread"
+        }
+    },
+    "hidden": true
+}

--- a/kubejs/data/ht32/powers/flight.json
+++ b/kubejs/data/ht32/powers/flight.json
@@ -1,5 +1,19 @@
 {
-    "type": "origins:creative_flight",
+    "type": "origins:multiple",
+    "fly": {
+        "type": "origins:creative_flight"
+    },
+    "exhaust": {
+        "type": "origins:action_over_time",
+        "interval": 2,
+        "entity_action": {
+            "type": "origins:exhaust",
+            "amount": 0.02
+        },
+        "condition": {
+            "type": "origins:creative_flying"
+        }
+    },
     "name": "Flight",
     "description": "You can fly!"
 }

--- a/kubejs/data/ht32/powers/hively_home.json
+++ b/kubejs/data/ht32/powers/hively_home.json
@@ -13,10 +13,21 @@
         "type": "origins:empty"
     },
     "entity_action": {
-        "type": "origins:change_resource",
-        "resource": "ht32:pollinator_stored",
-        "change": 0,
-        "operation": "set"
+        "type": "origins:and",
+        "actions": [
+            {
+                "type": "origins:change_resource",
+                "resource": "ht32:pollinator_stored",
+                "change": 0,
+                "operation": "set"
+            },
+            {
+                "type": "origins:give",
+                "stack": {
+                    "item": "the_bumblezone:pollen_puff"
+                }
+            }
+        ]
     },
     "condition": {
         "type": "origins:resource",

--- a/kubejs/data/ht32/recipes/bee_bread.json
+++ b/kubejs/data/ht32/recipes/bee_bread.json
@@ -1,0 +1,17 @@
+{
+  "type": "create:filling",
+  "ingredients": [
+    {
+      "item": "the_bumblezone:pollen_puff"
+    },
+    {
+      "amount": 20250,
+      "fluidTag": "c:honey"
+    }
+  ],
+  "results": [
+    {
+      "item": "the_bumblezone:bee_bread"
+    }
+  ]
+}


### PR DESCRIPTION
-Barbed Stinger: Bumblekin deal poison and take 1.5 hearts of damage on attack.
-Bumblekin is now vulnerable to Bane of Arthropods.
-Bumblekin gains extra saturation and hunger from bee bread.
-Bee bread can now be crafted with a create spout.

-Reality Engine: Origin focused around the manipulation of gravity and time (entity speed mostly)
-Can decrease/increase their own gravity with jump/crouch.
-Applies random gravity effects while attacking entities.
-Receives several debuffs below 5 hearts. (decreased speed and increased gravity)